### PR TITLE
Custom Joplin es6 migration manager

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,20 +16,18 @@
                  [com.taoensso/timbre "4.8.0"]
                  [com.fzakaria/slf4j-timbre "0.3.7"]
                  [org.slf4j/log4j-over-slf4j "1.7.25"]
-                 [com.walmartlabs/lacinia "0.23.0"]
-                 [honeysql "0.9.1"]
                  [kixi/kixi.comms "0.2.31"]
                  [kixi/kixi.log "0.1.4"]
                  [kixi/kixi.metrics "0.4.0"]
                  [kixi/kixi.spec "0.1.13"]
                  [joplin.core "0.3.9"]
-                 [joplin.elasticsearch "0.3.9"]
                  [org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/tools.nrepl "0.2.12"]
                  [com.rpl/specter "1.0.5"]
                  [ring/ring-core "1.6.3"]
                  [ring/ring-jetty-adapter "1.6.3"]
                  [ring/ring-json "0.4.0"]]
+  :exclusions [org.clojure/clojure]
   :repl-options {:init-ns user}
   :global-vars {*warn-on-reflection* true
                 *assert* false}

--- a/src/joplin/elasticsearch6/database.clj
+++ b/src/joplin/elasticsearch6/database.clj
@@ -1,0 +1,199 @@
+(ns joplin.elasticsearch6.database
+  (:require [clj-time
+             [core :as t]
+             [format :as f]]
+            [clj-http.client :as client]
+            [joplin.core :refer [migrate-db
+                                 rollback-db
+                                 seed-db
+                                 pending-migrations
+                                 create-migration
+                                 get-migrations
+                                 do-migrate
+                                 do-rollback
+                                 do-seed-fn
+                                 do-pending-migrations
+                                 do-create-migration]]
+            [cheshire.core :as json]
+            [ragtime.protocols :refer [DataStore]]))
+
+(def default-migration-index "migrations")
+(def migration-type "migration")
+(def migration-document-id "0")
+
+(defn- get-migration-index [db]
+  (or (:migration-index db) default-migration-index))
+
+(defn kw->es-format
+  [kw]
+  (if (qualified-keyword? kw)
+    (str (clojure.string/replace (namespace kw) "." "_")
+         "__"
+         (name kw))
+    (name kw)))
+
+(defn es-format->kw
+  [confused-kw]
+  (let [splits (clojure.string/split (name confused-kw) #"__")]
+    (if (second splits)
+      (keyword
+       (clojure.string/replace (first splits) "_" ".")
+       (second splits))
+      confused-kw)))
+
+(defn map-all-keys
+  [f]
+  (fn mapper [m]
+    (cond
+      (map? m) (zipmap (map f (keys m))
+                       (map mapper (vals m)))
+      (list? m) (map mapper m)
+      (vector? m) (mapv mapper m)
+      (seq? m) (str m) ; (map mapper m) spec errors contain seq's of sexp's containing code, which breaks elasticsearch validation.
+      (symbol? m) (name m)
+      (keyword? m) (f m)
+      :else m)))
+
+(defn kw->es-format
+  [kw]
+  (if (qualified-keyword? kw)
+    (str (clojure.string/replace (namespace kw) "." "_")
+         "__"
+         (name kw))
+    (name kw)))
+
+(defn es-format->kw
+  [confused-kw]
+  (let [splits (clojure.string/split (name confused-kw) #"__")]
+    (if (second splits)
+      (keyword
+       (clojure.string/replace (first splits) "_" ".")
+       (second splits))
+      confused-kw)))
+
+
+(def all-keys->es-format
+  (map-all-keys kw->es-format))
+
+(def all-keys->kw
+  (map-all-keys es-format->kw))
+
+(defn insert
+  [es-url index-name doc-type id document]
+  (client/put (str es-url "/" index-name "/" doc-type "/" id)
+              {:body (json/generate-string
+                      (all-keys->es-format document))
+               :as :json
+               :headers {:content-type "application/json"}}))
+
+(defn index-exists?
+  [es-url index-name]
+  (-> (str es-url "/" index-name)
+      (client/head {:throw-exceptions false})
+      :status
+      (= 200)))
+
+(defn create-index
+  [es-url index-name]
+  (client/put (str es-url "/" index-name)))
+
+(defn get-data
+  [es-url index-name doc-type id]
+  (let [resp (client/get
+              (str es-url "/" index-name "/" doc-type "/" id)
+              {:throw-exceptions false})]
+    (when (= 200 (:status resp))
+      (-> (:body resp)
+          (json/parse-string keyword)
+          :_source
+          all-keys->kw))))
+
+(defn- ensure-migration-index
+  [es-url migration-index]
+  (when-not (index-exists? es-url migration-index)
+    (create-index es-url
+                  migration-index)))
+
+(defn- timestamp-as-string
+  []
+  (f/unparse (f/formatters :date-time) (t/now)))
+
+(defn- es-get-applied
+  [es-url migration-index]
+  (ensure-migration-index es-url migration-index)
+  (some->> (get-data es-url
+                     migration-index
+                     migration-type
+                     migration-document-id)
+           :_source
+           :migrations
+           es-format->kw))
+
+(defn es-add-migration-id
+  [es-url migration-index migration-id]
+  (insert es-url
+          migration-index
+          migration-type
+          migration-document-id
+          {:migrations
+           (assoc
+            (es-get-applied es-url migration-index)
+            migration-id
+            (timestamp-as-string))}))
+
+(defn es-remove-migration-id
+  [es-url migration-index migration-id]
+  (insert es-url
+          migration-index
+          migration-type
+          migration-document-id
+          {:migrations
+           (dissoc
+            (es-get-applied es-url migration-index)
+            migration-id
+            (timestamp-as-string))}))
+
+(defn es-get-applied-migrations
+  [es-client migration-index]
+  (or (some->> (es-get-applied es-client migration-index)
+               (sort-by second)
+               keys
+               (map name))
+      []))
+
+(defn es-url
+  [protocol host port]
+  (str protocol "://" host ":" port))
+
+(defrecord ES6Database
+    [protocol host port index migration-index cluster]
+  DataStore
+  (add-migration-id [db id]
+    (es-add-migration-id (es-url protocol host port)
+                         (get-migration-index db) id))
+  (remove-migration-id [db id]
+    (es-remove-migration-id (es-url protocol host port)
+                            (get-migration-index db) id))
+  (applied-migration-ids [db]
+    (es-get-applied-migrations (es-url protocol host port)
+                               (get-migration-index db))))
+
+
+(defmethod migrate-db :es6 [target & args]
+  (apply do-migrate (get-migrations (:migrator target))
+         (map->ES6Database (:db target)) args))
+
+(defmethod rollback-db :es6 [target amount-or-id & args]
+  (apply do-rollback (get-migrations (:migrator target))
+         (->ES6Database target) amount-or-id args))
+
+(defmethod seed-db :es6 [target & args]
+  (apply do-seed-fn (get-migrations (:migrator target))
+         (->ES6Database target) target args))
+
+(defmethod pending-migrations :es6 [target & args]
+  (do-pending-migrations (->ES6Database target)
+                         (get-migrations (:migrator target))))
+
+(defmethod create-migration :es6 [target id & args]
+  (do-create-migration target id "joplin.elasticsearch6.database"))

--- a/src/kixi/search/elasticsearch.clj
+++ b/src/kixi/search/elasticsearch.clj
@@ -366,7 +366,9 @@
                  index-name
                  {:mappings {doc-type
                              {:properties (all-keys->es-format definition)}}
-                  :settings {:number_of_shards 1 ;; See https://www.elastic.co/guide/en/elasticsearch/guide/master/relevance-is-broken.html
+                  :settings {:number_of_shards 1
+                             ;; TODO SORT THIS OUT BEFORE MASTER MERGE
+                             ;; See https://www.elastic.co/guide/en/elasticsearch/guide/master/relevance-is-broken.html
                              :analysis {:filter {:autocomplete_filter
                                                  {:type "edge_ngram"
                                                   :min_gram 1 ;; Might want this to be 2

--- a/src/kixi/search/elasticsearch/event_handlers/metadata_create.clj
+++ b/src/kixi/search/elasticsearch/event_handlers/metadata_create.clj
@@ -11,24 +11,7 @@
 (def index-name "kixi-datastore_file-metadata")
 (def doc-type "file-metadata")
 
-;;TODO Move this into some Joplin like thing
-(def doc-def
-  {::md/id es/string-stored-not_analyzed
-   ::md/type es/string-stored-not_analyzed
-   ::md/file-type es/string-stored-not_analyzed
-   ::md/name es/string-autocomplete
-   ::md/description es/string-analyzed
-   ::md/tags es/string-autocomplete
-   ::md/provenance {:properties {::md/source es/string-stored-not_analyzed
-                                 :kixi.user/id es/string-stored-not_analyzed
-                                 ::md/parent-id es/string-stored-not_analyzed
-                                 ::md/created es/timestamp}}
-   ::md/sharing {:properties (zipmap md/activities
-                                     (repeat es/string-stored-not_analyzed))}
-   ::md/size-bytes es/long})
-
 (def local-es-url "http://localhost:9200")
-
 
 (defn insert-metadata
   [es-url metadata]

--- a/src/kixi/search/elasticsearch/index_manager.clj
+++ b/src/kixi/search/elasticsearch/index_manager.clj
@@ -1,0 +1,39 @@
+(ns kixi.search.elasticsearch.index-manager
+  (:require [com.stuartsierra.component :as component]
+            [kixi.search.elasticsearch :as es]
+            [kixi.spec :refer [alias]]
+            [joplin.repl :as jrepl]
+            [taoensso.timbre :as timbre :refer [info]]
+            [kixi.datastore.metadatastore :as md]))
+
+(defn migrate
+  [env migration-conf]
+  (->>
+   (with-out-str
+     (jrepl/migrate migration-conf env))
+   (clojure.string/split-lines)
+   (run! #(prn "JOPLIN:" %))))
+
+(defrecord IndexManager
+    [started host port protocol]
+  component/Lifecycle
+  (start [component]
+    (if-not started
+      (let [joplin-conf {:migrators {:migrator "joplin/kixi/search/elasticsearch/migrators/"}
+                         :databases {:es6 {:type :es6
+                                           :protocol protocol
+                                           :host host
+                                           :port port
+                                           :migration-index "kixi_search-migrations"}}
+                         :environments {:env [{:db :es6
+                                               :migrator :migrator}]}}]
+        (info "Starting Elastic Search Index Manager")
+        (migrate :env joplin-conf)
+        (assoc component :started true))
+      component))
+  (stop [component]
+    (if started
+      (do (info "Stopping Elastic Search Index Manager")
+          (dissoc component
+                  :started))
+      component)))

--- a/src/kixi/search/elasticsearch/migrators/migrate_20180129.clj
+++ b/src/kixi/search/elasticsearch/migrators/migrate_20180129.clj
@@ -1,0 +1,39 @@
+(ns kixi.search.elasticsearch.migrators.migrate-20180129
+  (:require [com.stuartsierra.component :as component]
+            [kixi.search.elasticsearch :as es]
+            [taoensso.timbre :as timbre :refer [info]]
+            [kixi.datastore.metadatastore :as md]))
+
+
+(def index-name "kixi-datastore_file-metadata")
+(def doc-type "file-metadata")
+
+;;TODO this needs to be complete
+(def index-definition
+  {::md/id es/string-stored-not_analyzed
+   ::md/type es/string-stored-not_analyzed
+   ::md/file-type es/string-stored-not_analyzed
+   ::md/name es/string-autocomplete
+   ::md/description es/string-analyzed
+   ::md/tags es/string-autocomplete
+   ::md/provenance {:properties {::md/source es/string-stored-not_analyzed
+                                 :kixi.user/id es/string-stored-not_analyzed
+                                 ::md/parent-id es/string-stored-not_analyzed
+                                 ::md/created es/timestamp}}
+   ::md/sharing {:properties (zipmap md/activities
+                                     (repeat es/string-stored-not_analyzed))}
+   ::md/size-bytes es/long})
+
+(defn es-url
+  [{:keys [protocol host port]}]
+  (str protocol "://" host ":" port))
+
+(defn up
+  [db]
+  (es/create-index (es-url db)
+                   index-name
+                   doc-type
+                   index-definition))
+
+(defn down
+  [db])

--- a/src/kixi/search/web.clj
+++ b/src/kixi/search/web.clj
@@ -3,9 +3,6 @@
             [clojure.edn :as edn]
             [cheshire.core :as json]
             [clojure.spec.alpha :as spec]
-            [com.walmartlabs.lacinia.util :refer [attach-resolvers]]
-            [com.walmartlabs.lacinia :refer [execute]]
-            [com.walmartlabs.lacinia.schema :as schema]
             [bidi
              [bidi :refer [tag]]
              [ring :refer [make-handler]]

--- a/test/kixi/acceptance/elasticsearch_test.clj
+++ b/test/kixi/acceptance/elasticsearch_test.clj
@@ -66,7 +66,8 @@
 (defn ensure-index
   [all-tests]
   (when-not (sut/index-exists? es-url mc/index-name)
-    (sut/create-index es-url mc/index-name mc/doc-type mc/doc-def))
+    ;;(sut/create-index es-url mc/index-name mc/doc-type mc/doc-def)
+    )
   (all-tests))
 
 (defn instrument

--- a/test/kixi/search_test.clj
+++ b/test/kixi/search_test.clj
@@ -3,8 +3,7 @@
             [clj-time.core :as t]
             [kixi.datastore.metadatastore :as md]
             [kixi.spec.conformers :as conformers]
-            [kixi.user :as user]
-            [kixi.search.elasticsearch.event-handlers.metadata-create :as es]))
+            [kixi.user :as user]))
 
 (comment "A large test suite that generates a fixed sequence of datastore events to build up a prod like dataset,
 Then performs various searches to explore the backends and how they perform.


### PR DESCRIPTION
Introduces a custom Joplin plugin for managing ElasticSearch 6, as the
available version does not support this version.

There is duplication between this plugin and other namespaces. This is
because it's envisioned that this code might be pushable back to the
project and so it needs to stand alone.

It hasn't really been fully tested out, but it does find migrations
and executes them, there might be some more tweaking to do as our
index evolves, but with this level we should be able to iterate.