### PR TITLE
Elasticsearch client apply-func complete

### DIFF
--- a/src/kixi/search/metadata/query.clj
+++ b/src/kixi/search/metadata/query.clj
@@ -37,7 +37,7 @@
   Query
   (find-by-id-
     [this id]
-    (es/get-document profile-index doc-type es-url id))
+    (es/get-by-id profile-index doc-type es-url id))
 
   (find-by-query-
     [this query-map from-index cnt sort-by sort-order]

--- a/src/kixi/search/system.clj
+++ b/src/kixi/search/system.clj
@@ -7,7 +7,7 @@
             [kixi.comms.components.kinesis :as kinesis]
             [kixi.log :as kixi-log]
             [kixi.search.elasticsearch.index-manager :as index-manager]
-            [kixi.search.metadata.event-handlers.update :as metadata-create]
+            [kixi.search.metadata.event-handlers.update :as metadata-update]
             [kixi.search.metadata.query :as metadata-query]
             [kixi.search.repl :as repl]
             [kixi.search.web :as web]
@@ -24,7 +24,7 @@
   {:communications []
    :repl []
    :metadata-query []
-   :metadata-create [:communications]
+   :metadata-update [:communications]
    :web [:metadata-query]})
 
 (defn new-system-map
@@ -37,7 +37,7 @@
    :index-manager (index-manager/map->IndexManager {})
 
    :metadata-query (metadata-query/map->ElasticSearch {})
-   :metadata-create (metadata-create/map->MetadataCreate {})
+   ;;   :metadata-update (metadata-update/map->MetadataCreate {})
 
    :repl (repl/map->ReplServer {})
    :web (web/map->Web {})))

--- a/test/kixi/search/metadata/event_handlers/update_test.clj
+++ b/test/kixi/search/metadata/event_handlers/update_test.clj
@@ -1,0 +1,56 @@
+(ns kixi.search.metadata.event-handlers.update-test
+  (:require [kixi.search.metadata.event-handlers.update :as sut]
+            [clojure.test :as t :refer [deftest is]]))
+
+(deftest remove-update-ns-test
+  (is (= :foo/bar
+         (sut/remove-update-ns :foo.update/bar))))
+
+(deftest top-level-set
+  (is (= {:foo/value "string"}
+         (sut/apply-updates
+          {:foo/value 1}
+          {:foo.update/value {:set "string"}}))))
+
+(deftest top-level-rm
+  (is (= {}
+         (sut/apply-updates
+          {:foo/value 1}
+          {:foo.update/value :rm}))))
+
+(deftest top-level-conj
+  (is (= {:foo/value [1 2]}
+         (sut/apply-updates
+          {:foo/value [1]}
+          {:foo.update/value {:conj 2}}))))
+
+(deftest top-level-disj
+  (is (= {:foo/value [1]}
+         (sut/apply-updates
+          {:foo/value [1 2]}
+          {:foo.update/value {:disj 2}}))))
+
+(deftest nested-set
+  (is (= {:foo/value {:bar/value "string"}}
+         (sut/apply-updates
+          {:foo/value {:bar/value 1}}
+          {:foo.update/value {:bar.update/value {:set "string"}}}))))
+
+(deftest nested-rm
+  (is (= {:foo/value {}}
+         (sut/apply-updates
+          {:foo/value {:bar/value 1}}
+          {:foo.update/value {:bar.update/value :rm}}))))
+
+(deftest multi-nested-update
+  (is (= {:foo/value {:bar/value "string"
+                      :bar/other "string"
+                      :bar/new "string"}}
+         (sut/apply-updates
+          {:foo/value {:bar/value 1
+                       :bar/other 1
+                       :bar/also 1}}
+          {:foo.update/value {:bar.update/value {:set "string"}
+                              :bar.update/other {:set "string"}
+                              :bar.update/also :rm
+                              :bar.update/new {:set "string"}}}))))


### PR DESCRIPTION
Adds the ability to apply a function to a document stored in
elasticsearch. I've decided not support the usual case of retrying on
concurrent update failures as we shouldn't encounter these, so it just
felt like uneeded complication.

The acceptance tests explore the problem and prove that an informative
exception will be produced. For use it will mean a consumer
shutdown. If these prove to occur more than expected, then the try
loop can be reintroduced without much bother.

Metadata update component disabled as it's not ready yet.