### PR TITLE
Allow day only timestamps in date fields

### DIFF
--- a/src/kixi/search/time.clj
+++ b/src/kixi/search/time.clj
@@ -4,4 +4,5 @@
 
 (def format :basic-date-time)
 
-(def es-format (clojure.string/replace (name format) "-" "_"))
+(def es-format
+  (str (clojure.string/replace (name format) "-" "_") "||" "yyyyMMdd"))


### PR DESCRIPTION
We have a mixture of datetime and dates in our time fields. This
change makes it so both formats are acceptable.