### PR TITLE
Remove integration test deletion of command processor table

### DIFF
--- a/test/kixi/search/integration_tests.clj
+++ b/test/kixi/search/integration_tests.clj
@@ -43,8 +43,7 @@
   [{:keys [endpoint dynamodb-endpoint streams
            profile app teardown-kinesis teardown-dynamodb]}]
   (when teardown-dynamodb
-    (delete-tables dynamodb-endpoint [(kinesis/event-worker-app-name app profile)
-                                      (kinesis/command-worker-app-name app profile)]))
+    (delete-tables dynamodb-endpoint [(kinesis/event-worker-app-name app profile)]))
   (when teardown-kinesis
     (kinesis/delete-streams! endpoint (vals streams))))
 


### PR DESCRIPTION
We don't have a command processor, so we don't need to delete the
kinesis table for it.