### PR TITLE
Allow type overides for query model specs

### DIFF
--- a/test/kixi/search/acceptance/elasticsearch_test.clj
+++ b/test/kixi/search/acceptance/elasticsearch_test.clj
@@ -128,7 +128,7 @@
     (insert-data uid data)
     (wait-is= data
               ((comp first :items) (search-data {:query {::md/name {:match "Test File"}
-                                                         ::md/sharing {::md/meta-read {:contains [uid]}}}}))))  )
+                                                         ::md/sharing {::md/meta-read {:contains [uid]}}}})))))
 
 (deftest search-by-sharing-and-type
   (let [uid (uuid)

--- a/test/kixi/search/query_model_tests.clj
+++ b/test/kixi/search/query_model_tests.clj
@@ -9,7 +9,9 @@
 
 (deftest name-query
   (is (spec/valid? ::sut/query-map
-                   {:query {::msq/name {:match "a"}}})))
+                   {:query {::msq/name {:match "a"}}}))
+  (is (spec/valid? ::sut/query-map
+                   {:query {::msq/name {:match "["}}})))
 
 (deftest name-fields-query
   (is (spec/valid? ::sut/query-map
@@ -17,3 +19,25 @@
                     :fields [::ms/name ::ms/id
                              [::ms/provenance ::ms/created]
                              [::ms/provenance :kixi.user/id]]})))
+
+(deftest to-homogeneous-test
+  (is (= {::ms/name {:predicates #{:match}}
+          ::ms/sharing {::ms/meta-read {:predicates #{:contains}}}}
+         (sut/to-homogeneous
+          {::ms/name #{:match}
+           ::ms/sharing {::ms/meta-read #{:contains}}})))
+  (is (= {::ms/name {:predicates #{:match}}
+          ::ms/foo {:predicates #{:match}}
+          ::ms/sharing {::ms/meta-read {:predicates #{:contains}}
+                        ::ms/bar {:predicates #{:contains}}}}
+         (sut/to-homogeneous
+          {::ms/name #{:match}
+           ::ms/foo {:predicates #{:match}}
+           ::ms/sharing {::ms/meta-read #{:contains}
+                         ::ms/bar {:predicates #{:contains}}}}))))
+
+(deftest all-specs-with-actions-test
+  (is (= '([:kixi.datastore.metadatastore/name {:predicates #{:match}}]
+           [:kixi.datastore.metadatastore/meta-read {:predicates #{:contains}}])
+         (sut/all-specs-with-actions {::ms/name {:predicates #{:match}}
+                                      ::ms/sharing {::ms/meta-read {:predicates #{:contains}}}}))))


### PR DESCRIPTION
This allows us to accepts invalid file names as searches for file
names. Previously this wasn't possible due to the spec for the query
term being constrained to the normal file name spec.