### PR TITLE
Match queries favour first word in phrase

### DIFF
--- a/src/kixi/search/elasticsearch/client.clj
+++ b/src/kixi/search/elasticsearch/client.clj
@@ -204,7 +204,14 @@
                       {:must (vector-when-multi
                                  (mapv
                                   inject-standard-analyzer
-                                  (wrap-query-type :match matchers)))})
+                                  (wrap-query-type :match matchers)))
+                       :should (vector-when-multi
+                                   (mapv
+                                    #(hash-map :span_first
+                                               {:match %
+                                                :end 1})
+                                    (wrap-query-type :span_term
+                                                     matchers)))})
                     (when-let [exists (select-nested
                                        flat-query
                                        "exists")]

--- a/test/kixi/search/acceptance/elasticsearch_test.clj
+++ b/test/kixi/search/acceptance/elasticsearch_test.clj
@@ -174,14 +174,14 @@
                                                                        ::md/meta-update {:contains [uid]}}}})))
     (wait-is= data
               ((comp first :items) (search-data {:query {::md/name {:match "Test File"}
-                                                         ::md/provenance {::md/source {:match "upload"}}
+                                                         ::md/provenance {::md/source {:equals "upload"}}
                                                          ::md/type {:equals "stored"}
                                                          ::md/file-type {:equals "csv"}
                                                          ::md/sharing {::md/meta-read {:contains [uid]}
                                                                        ::md/meta-update {:contains [uid]}}}})))
     (wait-is= nil
               ((comp first :items) (search-data {:query {::md/name {:match "Test File"}
-                                                         ::md/provenance {::md/source {:match "upload"}}
+                                                         ::md/provenance {::md/source {:equals "upload"}}
                                                          ::md/type {:equals "stored"
                                                                     :exists true}
                                                          ::md/file-type {:equals "csv"}

--- a/test/kixi/search/elasticsearch_test.clj
+++ b/test/kixi/search/elasticsearch_test.clj
@@ -31,6 +31,8 @@
             {:bool
              {:must {:match {"name" {:query "x"
                                      :analyzer "standard"}}}
+              :should {:span_first {:match {:span_term {"name" "x"}}
+                                    :end 1}}
               :filter
               {:terms {"sharing.meta-read" ["123"]}}}}}
            (sut/query->es-filter {:query


### PR DESCRIPTION
Adds a should condition of type span to match queries. The should
condition is span_first term, with a length of 1. This should cause
matches where the match is of the first word in the phrase to be
ranked higher in the results.