### PR TITLE
Fixing ES data formatting

### DIFF
--- a/src/kixi/search/elasticsearch/client.clj
+++ b/src/kixi/search/elasticsearch/client.clj
@@ -73,11 +73,10 @@
                        (map mapper (vals m)))
       (list? m) (map mapper m)
       (vector? m) (mapv mapper m)
-      (seq? m) (str m) ; (map mapper m) spec errors contain seq's of sexp's containing code, which breaks elasticsearch validation.
+      (seq? m) (map mapper m)
       (symbol? m) (name m)
       (keyword? m) (f m)
       :else m)))
-
 
 (defn remove-query-sub-ns
   [k]

--- a/src/kixi/search/metadata/event_handlers/update.clj
+++ b/src/kixi/search/metadata/event_handlers/update.clj
@@ -91,9 +91,10 @@
 
 (defn- to-seq
   [x]
-  (if (coll? x)
-    x
-    (vector x)))
+  (cond
+    (coll? x) x
+    (nil? x) x
+    :else (vector x)))
 
 (defn apply-update
   [current kw update-cmd]
@@ -137,12 +138,10 @@
 (defmethod update-metadata-processor ::cs/file-metadata-update
   [es-url index-name update-event]
   (info "Update: " update-event)
-  (when-not (= "891cd066-ddeb-43f7-bbe3-d854c663c4ad"
-               (::md/id update-event))
-    (es/apply-func index-name doc-type es-url
-                   (::md/id update-event)
-                   #(apply-updates %
-                                   (dissoc-nonupdates update-event)))))
+  (es/apply-func index-name doc-type es-url
+                 (::md/id update-event)
+                 #(apply-updates %
+                                 (dissoc-nonupdates update-event))))
 
 (defn response-event
   [r]

--- a/test/kixi/search/elasticsearch_test.clj
+++ b/test/kixi/search/elasticsearch_test.clj
@@ -78,3 +78,11 @@
                [{:provenance {:created :desc}}
                 :name
                 {:provenance :created}]))))
+
+(deftest map-all-keys-test
+  (is (= {"foo__bar" [1]}
+         (sut/all-keys->es-format {:foo/bar [1]})))
+  (is (= {"foo__bar" '(1)}
+         (sut/all-keys->es-format {:foo/bar '(1)})))
+  (is (= {"foo__bar" '(1)}
+         (sut/all-keys->es-format {:foo/bar (remove #{2} [1 2])}))))

--- a/test/kixi/search/metadata/event_handlers/update_test.clj
+++ b/test/kixi/search/metadata/event_handlers/update_test.clj
@@ -27,9 +27,17 @@
   (is (= {:foo/value [1 2]}
          (sut/apply-updates
           {:foo/value 1}
+          {:foo.update/value {:conj 2}})))
+  (is (= {:foo/value [2]}
+         (sut/apply-updates
+          {}
           {:foo.update/value {:conj 2}}))))
 
 (deftest top-level-disj
+  (is (= {:foo/value []}
+         (sut/apply-updates
+          {}
+          {:foo.update/value {:disj 2}})))
   (is (= {:foo/value [1]}
          (sut/apply-updates
           {:foo/value [1 2]}


### PR DESCRIPTION
Previous the formatter was incorrectly parsing sequences into strings,
to allow some old prototype functionality. This change removes that
ill conceived idea.

This change also removes the hack to avoid a broken event in the
stream, which has now been fixed.